### PR TITLE
feat: add Docker deployment with nginx and HTTPS support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.next
+node_modules
+npm-debug.log
+.dockerignore
+.git
+.gitignore
+coverage
+*.log
+.DS_Store
+.env*
+nginx/ssl
+agents.md

--- a/DOCKER_SETUP.md
+++ b/DOCKER_SETUP.md
@@ -1,0 +1,95 @@
+# Docker HTTPS Setup for Geolocation Testing
+
+## Overview
+
+This setup enables testing the Geolocation API on mobile devices by providing HTTPS access through nginx reverse proxy on the `geoloc-docker-network`.
+
+## Architecture
+
+```text
+[Mobile Device] --> HTTPS:443 --> [nginx:alpine] --> HTTP:3000 --> [Next.js App]
+                                        |
+                                  geoloc-docker-network
+```
+
+## Components
+
+### 1. nginx (Reverse Proxy)
+
+- **Image**: `nginx:alpine`
+- **Ports**: 80 (HTTP redirect), 443 (HTTPS)
+- **Config**: [nginx/nginx.conf](nginx/nginx.conf)
+  - TLS 1.2/1.3 support
+  - Security headers (HSTS, X-Frame-Options, etc.)
+  - Proxies to internal `web:3000` service
+  - Auto-redirects HTTP to HTTPS
+
+### 2. Next.js Application
+
+- **Image**: Built from [Dockerfile](Dockerfile)
+- **Internal Port**: 3000 (not exposed to host)
+- **Network**: `geoloc-docker-network`
+- **Healthcheck**: wget on [http://localhost:3000](http://localhost:3000)
+
+### 3. SSL Certificates
+
+- **Location**: `nginx/ssl/` (git-ignored)
+- **Type**: Self-signed (development only)
+- **Generation**: Run `./nginx/generate-ssl.sh`
+- **Validity**: 365 days
+- **SANs**: localhost, 127.0.0.1, common private IP ranges
+
+## Quick Start
+
+1. **Generate SSL certificates** (first time only):
+
+   ```bash
+   ./nginx/generate-ssl.sh
+   ```
+
+2. **Start services**:
+
+   ```bash
+   docker compose up --build
+   ```
+
+3. **Access from phone**:
+
+   - Find Mac IP: `ipconfig getifaddr en0`
+   - Navigate to: `https://<your-ip>`
+   - Accept certificate warning
+
+## Development Mode
+
+For hot-reload during development:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+```
+
+This mounts your source code and runs `next dev` with file watching enabled.
+
+## Security Notes
+
+- **Self-signed certificates** will trigger browser warnings
+- Users must manually accept the certificate to enable geolocation
+- For production, replace with valid certificates (Let's Encrypt, etc.)
+- Current nginx config uses strong ciphers and modern TLS protocols
+
+## Troubleshooting
+
+### Geolocation still not working?
+
+- Ensure you're using HTTPS (not HTTP)
+- Accept the certificate warning in your browser
+- Check browser console for errors
+
+### Certificate issues?
+
+- Regenerate: `rm -rf nginx/ssl && ./nginx/generate-ssl.sh`
+- Ensure the IP you're accessing is covered by SANs in the cert
+
+### Container issues?
+
+- Check logs: `docker compose logs nginx` or `docker compose logs web`
+- Verify network: `docker network inspect geoloc-docker-network`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Multi-stage build for Next.js app
+FROM node:current-alpine AS base
+WORKDIR /app
+
+# Install production deps separately for a slimmer runtime image
+FROM base AS deps
+RUN apk add --no-cache libc6-compat
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM deps AS builder
+ENV NEXT_TELEMETRY_DISABLED=1
+COPY . .
+RUN npm run build
+
+FROM base AS runner
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+# Only keep production dependencies
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+# Copy the build output and public assets
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/next.config.ts ./next.config.ts
+
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,19 @@
+networks:
+  trilhos-docker-network:
+    name: trilhos-docker-network
+
+services:
+  web:
+    command: npm run dev -- --hostname 0.0.0.0 --port 3000
+    volumes:
+      - ./:/app
+      - /app/node_modules
+      - /app/.next
+    environment:
+      NODE_ENV: development
+      NEXT_TELEMETRY_DISABLED: "1"
+      CHOKIDAR_USEPOLLING: "1"
+    expose:
+      - "3000"
+    networks:
+      - trilhos-docker-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+networks:
+  trilhos-docker-network:
+    name: trilhos-docker-network
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: trilhos-next:latest
+    expose:
+      - "3000"
+    environment:
+      NODE_ENV: production
+      NEXT_TELEMETRY_DISABLED: "1"
+      HOSTNAME: 0.0.0.0
+      PORT: "3000"
+    networks:
+      - trilhos-docker-network
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/ssl:/etc/nginx/ssl:ro
+    networks:
+      - trilhos-docker-network
+    depends_on:
+      - web
+    restart: unless-stopped

--- a/nginx/.gitignore
+++ b/nginx/.gitignore
@@ -1,0 +1,2 @@
+# Ignore SSL certificates (they should be generated locally)
+ssl/

--- a/nginx/generate-ssl.sh
+++ b/nginx/generate-ssl.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+SSL_DIR="/Users/pfjn/Documents/Dev/Web/v0/v0_geolocation/nginx/ssl"
+mkdir -p "$SSL_DIR"
+
+if [ ! -f "$SSL_DIR/cert.pem" ] || [ ! -f "$SSL_DIR/key.pem" ]; then
+    echo "Generating self-signed SSL certificate..."
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+        -keyout "$SSL_DIR/key.pem" \
+        -out "$SSL_DIR/cert.pem" \
+        -subj "/C=US/ST=State/L=City/O=Development/CN=localhost" \
+        -addext "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:192.168.0.0/16,IP:10.0.0.0/8,IP:172.16.0.0/12"
+    echo "SSL certificate generated at $SSL_DIR"
+else
+    echo "SSL certificate already exists at $SSL_DIR"
+fi

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,33 @@
+server {
+    listen 80;
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate /etc/nginx/ssl/cert.pem;
+    ssl_certificate_key /etc/nginx/ssl/key.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    # Security headers
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+
+    location / {
+        proxy_pass http://web:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}


### PR DESCRIPTION
Closes #6

- Add multi-stage Dockerfile for optimized production builds
- Add development docker-compose with hot reload
- Add production docker-compose with nginx reverse proxy
- Include SSL certificate generation script
- Configure nginx for HTTPS and reverse proxying
- Add Docker setup documentation
- Port mapping: 3000 internal to 80/443 external via nginx