### PR TITLE
fix: Set a single string to dev origins.

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,7 @@ const nextConfig: NextConfig = {
   /* config options here */
   allowedDevOrigins: ['local-origin.dev', '*.local-origin.dev'],
   async headers() {
-    const devOrigin = process.env.DEV_CORS_ORIGIN ?? allowedDevOrigins;
+    const devOrigin = process.env.DEV_CORS_ORIGIN ?? "local-origin.dev";
     // In production, do not fall back to the development origin; use an explicit value or a safe default.
     const prodOrigin = process.env.CORS_ALLOWED_ORIGIN ?? "";
     const corsOrigin = process.env.NODE_ENV === "production" ? prodOrigin : devOrigin;


### PR DESCRIPTION
This pull request updates the CORS configuration logic in the `next.config.ts` file to improve clarity and safety in determining the allowed origins for development and production environments.

Configuration changes:

* The `devOrigin` variable now defaults to the string `"local-origin.dev"` instead of the `allowedDevOrigins` array, ensuring a single, explicit development origin is used when the `DEV_CORS_ORIGIN` environment variable is not set.